### PR TITLE
Fix wrong-number-of-arguments error from lsp-metals--model-refresh.

### DIFF
--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -356,7 +356,7 @@ PARAMS are the action params."
            :request "launch"
            :noDebug no-debug))))
 
-(defun lsp-metals--model-refresh (workspace)
+(defun lsp-metals--model-refresh (workspace _)
   "Handle `metals-model-refresh' notification refreshing lenses.
 WORKSPACE is the workspace the notification was received from."
   (->> workspace


### PR DESCRIPTION
This was causing the following error:

```
Error processing message (wrong-number-of-arguments ((t) (workspace) "Handle `metals-model-refresh' notification refreshing lenses.
WORKSPACE is the workspace the notification was received from." (mapc #'(lambda (buffer) (save-current-buffer (set-buffer buffer) (if (and (boundp 'lsp-lens-mode) lsp-lens-mode) (progn (lsp--lens-schedule-refresh t))))) (progn (or (and (memq (type-of workspace) cl-struct-lsp--workspace-tags) t) (signal 'wrong-type-argument (list 'lsp--workspace workspace))) (aref workspace 9)))) 2).
```
