### PR TITLE
Change starting slot for treeview position from 0 to 1

### DIFF
--- a/lsp-metals-treeview.el
+++ b/lsp-metals-treeview.el
@@ -314,7 +314,7 @@ then show the window."
                   nil)))
     (when (or (eq 'hidden visibility) (eq 'none visibility))
       (lsp-metals-treeview--show-views workspace
-                                     views 0 select-window?))))
+                                     views 1 select-window?))))
 
 (defun lsp-metals-treeview--delete-window (&optional workspace workspace-shutdown?)
   "Delete the metals treeview window associated with the WORKSPACE.
@@ -457,7 +457,7 @@ Select the first view/buffer in the treeview window."
   "Display each view returned by Metals in our sidebar treeview window.
 Views are displayed for this WORKSPACE, VIEWS is a list of alist containing
 the views taken from the lsp-metals-treeview--data structure.  SLOT is a
-numeric position starting from 0 where the treeview will be positioned
+numeric position starting from 1 where the treeview will be positioned
 relative to the others.  when SELECT-TREEVIEW-WINDOW is 't' the treeview
 window will be selected and have focus."
   (if (not (null views))
@@ -512,7 +512,7 @@ by Metals in this case."
               (lsp-metals-treeview--exists? workspace))
       (lsp-metals-treeview--show-views workspace
                                      (and state (lsp-metals-treeview--data-views state))
-                                     0))))
+                                     1))))
 
 
 (defun lsp-metals-treeview--cache-add-nodes (metals-nodes current-treemacs-node)


### PR DESCRIPTION
Fixes #14.

I changed the constant to 1 here at both callsites but could also just add 1 to it in the `lsp-metals-treeview--show-views` function instead.

This also does change the behavior from replacing the file tree buffer (which I guess is slot 0 by default) to opening a new window under it. I feel like this is a positive (and hopefully uncontroversial) change, but can imagine why it might be something a user would want to configure.