### PR TITLE
Remove duplicated lsp-metals-scalafmt-config-path

### DIFF
--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -105,14 +105,6 @@ It's used for indexing JDK sources and locating the `java' binary."
   :group 'lsp-metals
   :package-version '(lsp-metals . "1.0"))
 
-(defcustom lsp-metals-scalafmt-config-path ""
-  "Optional custom path to the .scalafmt.conf file.
-Should be relative to the workspace root directory and use forward
-slashes / for file separators (even on Windows)."
-  :type '(string)
-  :group 'lsp-metals
-  :package-version '(lsp-metals . "1.0"))
-
 (defcustom lsp-metals-sbt-script ""
   "Optional absolute path to an `sbt' executable.
 By default, Metals uses `java -jar sbt-launch.jar' with an embedded
@@ -230,7 +222,6 @@ displayed either as additional decorations."
 
 (lsp-register-custom-settings
  '(("metals.java-home" lsp-metals-java-home)
-   ("metals.scalafmt-config-path" lsp-metals-scalafmt-config-path)
    ("metals.sbt-script" lsp-metals-sbt-script)
    ("metals.gradle-script" lsp-metals-gradle-script)
    ("metals.maven-script" lsp-metals-maven-script)

--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -105,6 +105,14 @@ It's used for indexing JDK sources and locating the `java' binary."
   :group 'lsp-metals
   :package-version '(lsp-metals . "1.0"))
 
+(defcustom lsp-metals-scalafmt-config-path ""
+  "Optional custom path to the .scalafmt.conf file.
+Should be relative to the workspace root directory and use forward
+slashes / for file separators (even on Windows)."
+  :type '(string)
+  :group 'lsp-metals
+  :package-version '(lsp-metals . "1.0"))
+
 (defcustom lsp-metals-sbt-script ""
   "Optional absolute path to an `sbt' executable.
 By default, Metals uses `java -jar sbt-launch.jar' with an embedded
@@ -138,14 +146,6 @@ customizations."
 By default, Metals uses mill wrapper script with 0.5.0 mill version.
 Update this setting if your mill script requires more customizations
 like using environment variables."
-  :type '(string)
-  :group 'lsp-metals
-  :package-version '(lsp-metals . "1.0"))
-
-(defcustom lsp-metals-scalafmt-config-path ".scalafmt.conf"
-  "Optional custom path to the .scalafmt.conf file.
-Should be relative to the workspace root directory and use forward
-slashes / for file separators (even on Windows)."
   :type '(string)
   :group 'lsp-metals
   :package-version '(lsp-metals . "1.0"))
@@ -222,11 +222,11 @@ displayed either as additional decorations."
 
 (lsp-register-custom-settings
  '(("metals.java-home" lsp-metals-java-home)
+   ("metals.scalafmt-config-path" lsp-metals-scalafmt-config-path)
    ("metals.sbt-script" lsp-metals-sbt-script)
    ("metals.gradle-script" lsp-metals-gradle-script)
    ("metals.maven-script" lsp-metals-maven-script)
    ("metals.mill-script" lsp-metals-mill-script)
-   ("metals.scalafmt-config-path" lsp-metals-scalafmt-config-path)
    ("metals.pants-targets" lsp-metals-pants-targets)
    ("metals.bloop-sbt-already-installed" lsp-metals-bloop-sbt-already-installed t)
    ("metals.bloop-version" lsp-metals-bloop-version)


### PR DESCRIPTION
Hi, 

I came across two `lsp-metals-scalafmt-config-path` variables. Is it intentional?
I think it is duplicated. Also, I am not sure if I am deleting the correct one.

Best,
