### PR TITLE
Fix deprecation notice on define-minor-mode

### DIFF
--- a/lsp-metals-treeview.el
+++ b/lsp-metals-treeview.el
@@ -332,7 +332,6 @@ the context of the window closing."
 
 (define-minor-mode lsp-metals-treeview-mode
   "LSP Metals Treeview minor mode."
-  nil nil nil
   :keymap lsp-metals-treeview-mode-map
   :group 'lsp-metals-treeview)
 


### PR DESCRIPTION
build-28.0.50/lsp-metals/lsp-metals-treeview.el: Warning: Use keywords rather than deprecated positional arguments to `define-minor-mode'