### PR TITLE
Resolve #57. Add project ID setting support to DAP debug templates to allow values other than 'root'

### DIFF
--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -541,7 +541,7 @@ FOCUSED if there is a focused frame."
                                                                             (error "The debug provide can be called under project root")))
                                                       "?id="
                                                       (or
-                                                       (plist-get conf :projectId)
+                                                       (plist-get conf :buildTarget)
                                                        "root"))))))))))
       (-> conf
           (dap--put-if-absent :name name)

--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -539,7 +539,10 @@ FOCUSED if there is a focused frame."
                                      (vector `(:uri ,(concat
                                                       (lsp--path-to-uri (or (lsp-workspace-root)
                                                                             (error "The debug provide can be called under project root")))
-                                                      "?id=root")))))))))
+                                                      "?id="
+                                                      (or
+                                                       (plist-get conf :projectId)
+                                                       "root"))))))))))
       (-> conf
           (dap--put-if-absent :name name)
           (dap--put-if-absent :request "launch")


### PR DESCRIPTION
This is to support project layouts that don't have an umbrella module with name `root` which encompasses all submodules. More details can be found in the corresponding issue (https://github.com/emacs-lsp/lsp-metals/issues/57).

This change introduces a new setting `projectId` which can be specified as part of the DAP configuration template. Here is an example of a template which uses a new setting:
```
(dap-register-debug-template
  "Scala Attach Core"
  (list :type "scala"
        :request "attach"
        :name "Scala Attach Core"
        :projectId "core"
        :hostName "localhost"
        :port 5005))
```
