### PR TITLE
Fix recently changed super-method-hierarchy command

### DIFF
--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -370,7 +370,7 @@ change it again."
   (interactive)
   (lsp-send-execute-command
    "super-method-hierarchy"
-   `(:document ,(lsp--buffer-uri) :position ,(lsp-point-to-position (point)))))
+   (lsp--text-document-position-params)))
 
 (defun lsp-metals--doctor-render (html)
   "Render the Metals doctor HTML in the current buffer."


### PR DESCRIPTION
This was changed by mistake by me, when doing some refactorings.

Found in lsp--text-document-position-params

I haven't tested it and if anyone could confirm it works I would be super thankful :pray: 