### PR TITLE
Remove needless quote

### DIFF
--- a/lsp-metals-treeview.el
+++ b/lsp-metals-treeview.el
@@ -83,8 +83,8 @@ different workspaces."
   "The theme for treeview icons."
   :group 'lsp-metals-treeview
   :type '(choice
-           (const :tag "Light" 'Metals-light)
-           (const :tag "Dark" 'Metals-dark))
+           (const :tag "Light" Metals-light)
+           (const :tag "Dark" Metals-dark))
   :package-version '(lsp-metals . "1.2"))
 
 (defvar-local lsp-metals-treeview--current-workspace nil


### PR DESCRIPTION
They are already quoted so they mean `''Metals-light` and `''Metals-dark`. It is wrong.

Development Emacs warns this as byte-compile warnings as below.

```
lsp-metals-treeview.el:82:12: Warning: defcustom for
    ‘lsp-metals-treeview-theme’ has syntactically odd type ‘'(choice (const
    :tag Light 'Metals-light) (const :tag Dark 'Metals-dark))’
```