### PR TITLE
Add a Command to Run 'scalafix-run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,5 @@ An example to setup `lsp-metals` using `use-package`:
   ;; formatting of multiline strings only. You might want to disable it so that
   ;; emacs can use indentation provided by scala-mode.
   (lsp-metals-server-args '("-J-Dmetals.allow-multiline-string-formatting=off"))
-  :hook ((scala-mode . lsp)
-         ;; Optional: run scalafix rules on the current buffer before saving
-         ;; requires metals >= v0.11.7.
-         (scala-mode . lsp-metals-run-scalafix-rules-on-save)))
+  :hook (scala-mode . lsp))
 ```

--- a/README.md
+++ b/README.md
@@ -20,5 +20,8 @@ An example to setup `lsp-metals` using `use-package`:
   ;; formatting of multiline strings only. You might want to disable it so that
   ;; emacs can use indentation provided by scala-mode.
   (lsp-metals-server-args '("-J-Dmetals.allow-multiline-string-formatting=off"))
-  :hook (scala-mode . lsp))
+  :hook ((scala-mode . lsp)
+         ;; Optional: run scalafix rules on the current buffer before saving
+         ;; requires metals >= v0.11.7.
+         (scala-mode . lsp-metals-run-scalafix-rules-on-save)))
 ```

--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -640,12 +640,6 @@ FOCUSED if there is a focused frame."
                                   cl-third
                                   string-to-number))))))
 
-(defun lsp-metals-run-scalafix-rules-on-save ()
-  "Run the \"scalafix-run\" command prior to saving the current buffer.
-This runs all scalafix rules on the current buffer.  Note this requires metals
-v0.11.7 or greater."
-  (add-hook 'before-save-hook #'lsp-metals-run-scalafix nil t))
-
 (dap-register-debug-provider "scala" #'lsp-metals-populate-config)
 
 (dap-register-debug-template

--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -425,6 +425,11 @@ change it again."
   (interactive)
   (lsp-metals-decode-file "tasty-decoded"))
 
+(defun lsp-metals-run-scalafix ()
+  "Run scalafix rules for the current buffer, requires metals >= v0.11.7."
+  (interactive)
+  (lsp-send-execute-command "scalafix-run" (lsp--text-document-position-params)))
+
 (defun lsp-metals--browse-url (url &rest _)
   "Handle `command:' matals URLs."
   (when-let* ((workspace (lsp-find-workspace 'metals default-directory))
@@ -635,6 +640,11 @@ FOCUSED if there is a focused frame."
                                   cl-third
                                   string-to-number))))))
 
+(defun lsp-metals-run-scalafix-rules-on-save ()
+  "Run the \"scalafix-run\" command prior to saving the current buffer.
+This runs all scalafix rules on the current buffer.  Note this requires metals
+v0.11.7 or greater."
+  (add-hook 'before-save-hook #'lsp-metals-run-scalafix nil t))
 
 (dap-register-debug-provider "scala" #'lsp-metals-populate-config)
 


### PR DESCRIPTION
Hi, this PR adds a new command `lsp-metals-run-scalafix` which runs the `scalafix-run` command (documentation: https://scalameta.org/metals/docs/integrations/new-editor/#run-all-scalafix-rules).

~I've also added a utility function for adding this command to `before-save-hook`, and added this to the example setup~.  I hope this is helpful, thanks :slightly_smiling_face: 