### PR TITLE
Require treemacs-extensions explicitly

### DIFF
--- a/lsp-metals-treeview.el
+++ b/lsp-metals-treeview.el
@@ -56,6 +56,11 @@
 (require 'lsp-treemacs)
 (require 'lsp-metals-protocol)
 
+;;
+;; treemacs-extensions is obsolete and no longer loaded via treemacs. Consider
+;; changing to treemacs-treelib.
+;;
+(require 'treemacs-extensions)
 
 (defcustom lsp-metals-treeview-logging nil
   "If non nil log treeview trace/debug messages to the 'lsp-log' for debugging."


### PR DESCRIPTION
This is a quick fix for #84, which at least gets us rid of the "Symbol's definition is void" error. We should eventually migrate to the API provided by treemacs-treelib.