### PR TITLE
Remove metals-model-refresh Handler

### DIFF
--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -662,7 +662,6 @@ WORKSPACE is the workspace the notification was received from."
                         (`"metals-diagnostics-focus" #'lsp-metals--diagnostics-focus)
                         (`"metals-goto-location" #'lsp-metals--goto-location)
                         (`"metals-echo-command" #'lsp-metals--echo-command)
-                        (`"metals-model-refresh" #'lsp-metals--model-refresh)
                         (`"metals-show-stacktrace" #'lsp-metals--show-stacktrace)
                         (`"reset-choice" #'lsp-metals--reset-choice)
                         (c (ignore (lsp-warn "Unknown metals client command: %s" c))))))
@@ -778,16 +777,6 @@ PARAMS are the action params."
            :request "launch"
            :noDebug no-debug))))
 
-(defun lsp-metals--model-refresh (workspace)
-  "Handle `metals-model-refresh' notification refreshing lenses.
-WORKSPACE is the workspace the notification was received from."
-  (->> workspace
-       (lsp--workspace-buffers)
-       (mapc (lambda (buffer)
-               (with-current-buffer buffer
-                 (when (bound-and-true-p lsp-lens-mode)
-                   (lsp-lens--schedule-refresh t)))))))
-
 (defun lsp-metals--status-string-keymap (workspace command?)
   "Keymap for `metals/status' notification.
 WORKSPACE is the workspace we received notification from.
@@ -843,7 +832,6 @@ WORKSPACE is the workspace we received notification from."
                   :notification-handlers (ht ("metals/executeClientCommand" #'lsp-metals--execute-client-command)
                                              ("metals/publishDecorations" #'lsp-metals--publish-decorations)
                                              ("metals/treeViewDidChange" #'lsp-metals-treeview--did-change)
-                                             ("metals-model-refresh" #'lsp-metals--model-refresh)
                                              ("metals/status" #'lsp-metals--status-string))
                   :request-handlers (ht ("metals/quickPick" #'lsp-metals--quick-pick)
                                         ("metals/inputBox" #'lsp-metals--input-box))


### PR DESCRIPTION
Hi, this PR removes `metals-model-refresh` handler as metals now supports `workspace/codeLens/refresh`, so the `metals-model-refresh` client command is deprecated (see https://github.com/scalameta/metals/blob/8488a02cbab8628b6bf990249bc5483badb705a1/metals/src/main/scala/scala/meta/internal/metals/ClientCommands.scala#L252).

Thanks!