### PR TITLE
tests(test.yml): Setup node is no longer required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,6 @@ jobs:
       with:
         version: ${{ matrix.emacs-version }}
 
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '16'
-
     - uses: emacs-eask/setup-eask@master
       with:
         version: 'snapshot'


### PR DESCRIPTION
This is no longer needed for [setup-eask](https://github.com/emacs-eask/setup-eask).