### PR TITLE
Fix lsp-metals initialization

### DIFF
--- a/lsp-metals-treeview.el
+++ b/lsp-metals-treeview.el
@@ -365,7 +365,7 @@ form '((side left))."
         (with-lsp-workspace workspace
           (with-selected-window window
             (set-window-dedicated-p window t)
-            (treemacs-initialize)
+            (treemacs-initialize metals-root)
 
             (setq-local lsp-metals-treeview--current-workspace workspace)
             (setq-local lsp-metals-treeview--view-id view-id)


### PR DESCRIPTION
Temporary fix for https://github.com/emacs-lsp/lsp-metals/issues/81 `Eager macro-expansion failure: %S" (wrong-number-of-arguments (1 . 1) 0`

This error is occurring even after `(require treemacs-extensions)` fix. Just passing an argument works.