### PR TITLE
fix: Drop Emacs 26.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 26.3
           - 27.2
           - 28.2
           - 29.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 * Add reset-choice command.
+* Drop emacs 26 support.
 
 ## 1.1.0
 * Migrate to lsp-protocol.

--- a/Eask
+++ b/Eask
@@ -12,7 +12,7 @@
 (source "gnu")
 (source "melpa")
 
-(depends-on "emacs" "26.1")
+(depends-on "emacs" "27.1")
 (depends-on "scala-mode")
 (depends-on "lsp-mode")
 (depends-on "lsp-treemacs")

--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2018-2019 Ross A. Baker <ross@rossabaker.com>, Evgeny Kurnevsky <kurnevsky@gmail.com>
 
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "26.1") (scala-mode "1.1") (lsp-mode "7.0") (lsp-treemacs "0.2") (dap-mode "0.3") (dash "2.18.0") (f "0.20.0") (ht "2.0") (treemacs "2.5") (posframe "1.4.1"))
+;; Package-Requires: ((emacs "27.1") (scala-mode "1.1") (lsp-mode "7.0") (lsp-treemacs "0.2") (dap-mode "0.3") (dash "2.18.0") (f "0.20.0") (ht "2.0") (treemacs "2.5") (posframe "1.4.1"))
 ;; Author: Ross A. Baker <ross@rossabaker.com>
 ;;         Evgeny Kurnevsky <kurnevsky@gmail.com>
 ;; Keywords: languages, extensions


### PR DESCRIPTION
See https://github.com/emacs-lsp/lsp-mode/pull/4126.