### PR TITLE
update required scala-mode version: 1.1 -> 0.23

### DIFF
--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2018-2019 Ross A. Baker <ross@rossabaker.com>, Evgeny Kurnevsky <kurnevsky@gmail.com>
 
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "27.1") (scala-mode "1.1") (lsp-mode "7.0") (lsp-treemacs "0.2") (dap-mode "0.3") (dash "2.18.0") (f "0.20.0") (ht "2.0") (treemacs "3.1") (posframe "1.4.1"))
+;; Package-Requires: ((emacs "27.1") (scala-mode "0.23") (lsp-mode "7.0") (lsp-treemacs "0.2") (dap-mode "0.3") (dash "2.18.0") (f "0.20.0") (ht "2.0") (treemacs "3.1") (posframe "1.4.1"))
 ;; Author: Ross A. Baker <ross@rossabaker.com>
 ;;         Evgeny Kurnevsky <kurnevsky@gmail.com>
 ;; Keywords: languages, extensions


### PR DESCRIPTION
scala-mode 1.1 does not exist; 0.23 is the current version. 

https://github.com/hvesalai/emacs-scala-mode/blob/master/scala-mode.el#L7

This breaks installing lsp-metals in my setup (use-package with elpaca).

1.1 was set as the dependency in https://github.com/emacs-lsp/lsp-metals/pull/48. I didn't chase why this was set any further than that.

