### PR TITLE
Update fallback version

### DIFF
--- a/lsp-metals.el
+++ b/lsp-metals.el
@@ -251,7 +251,7 @@ Metals will try to adjust the indentation to that of the current cursor."
   :group 'lsp-metals
   :package-version '(lsp-metals . "1.3"))
 
-(defcustom lsp-metals-fallback-scala-version "3.2.0"
+(defcustom lsp-metals-fallback-scala-version "3.3.3"
   "The Scala compiler version that is used as the default or fallback.
 Used when a file doesn't belong to any build target or the specified Scala
 version isn't supported by Metals.  This applies to standalone Scala files,


### PR DESCRIPTION
Using metals version 1.3.1, there is a deprecation message that suggests to update from Scala 3.2.0 to 3.3.3 as fallback version.

Since the 3.3.x series is LTS, I thought it would make sense to have that as a default value in the upstream package, instead of just solving it locally for my projects, or picking 3.2.2 as the closest supported version.

The entire message reads: `LSP :: You are using fallback Scala version 3.2.0, which is not supported in this version of Metals. Please upgrade to Scala version 3.3.3.`

My `metals` server, installed with Coursier, outputs these supported versions:

```shell
$ metals --version
metals 1.3.1

# Note:
#   Supported Scala versions:
#     Scala 3: 3.1.3, 3.2.2, 3.3.1, 3.3.2, 3.3.3
#     Scala 2:
#       2.11.12
#       2.12.19, 2.12.18, 2.12.17, 2.12.16, 2.12.12, 2.12.13, 2.12.14, 2.12.15
#       2.13.14, 2.13.11, 2.13.12, 2.13.13, 2.13.7, 2.13.8, 2.13.9, 2.13.10```