### PR TITLE
remove unsupported 27.2 CI coverage; add `aarch64-linux` coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         emacs-version:
           - 28.2
           - 29.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - 27.2
           - 28.2
           - 29.4
         experimental: [false]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         emacs-version:
+          - 27.2
           - 28.2
           - 29.4
         experimental: [false]
@@ -30,6 +31,11 @@ jobs:
           - os: windows-latest
             emacs-version: snapshot
             experimental: true
+        exclude:
+          - os: macos-latest
+            emacs-version: 27.2
+          - os: ubuntu-24.04-arm
+            emacs-version: 27.2
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,19 @@ jobs:
       with:
         version: ${{ matrix.emacs-version }}
 
-    - uses: emacs-eask/setup-eask@master
+    - name: Setup Eask
+      uses: emacs-eask/setup-eask@master
+      if: matrix.os != 'ubuntu-24.04-arm'
       with:
         version: 'snapshot'
+        architecture: 'x64'
+
+    - name: Setup Eask for linux-aarch64
+      uses: emacs-eask/setup-eask@master
+      if: matrix.os == 'ubuntu-24.04-arm'
+      with:
+        version: 'snapshot'
+        architecture: 'arm64'
 
     - name: Run tests
       run: 'make test'


### PR DESCRIPTION
`aarch64-darwin` build is failing for 27.2:
https://github.com/emacs-lsp/lsp-metals/actions/runs/12587001261/job/35081969020#step:3:335

Dependency https://github.com/purcell/nix-emacs-ci does not support it:
> Official release versions from 23.4 are supported on Linux; from 24.3 on Intel MacOS; and from 28.1 on ARM (Apple Silicon) MacOS
